### PR TITLE
TEEM-9600: Remove django.conf.urls.patterns()

### DIFF
--- a/database_email_backend/admin.py
+++ b/database_email_backend/admin.py
@@ -72,7 +72,7 @@ class EmailAdmin(admin.ModelAdmin):
 
     def get_urls(self):
         urlpatterns = super(EmailAdmin, self).get_urls()
-        from django.conf.urls import patterns, url, include
+        from django.conf.urls import url, include
 
         def wrap(view):
             def wrapper(*args, **kwargs):
@@ -81,13 +81,12 @@ class EmailAdmin(admin.ModelAdmin):
 
         appname = self.model._meta.app_label
 
-        urlpatterns = patterns(
-            '',
+        urlpatterns = [
             url(r'^(?P<email_id>\d+)/attachments/(?P<attachment_id>\d+)/'
                 r'(?P<filename>[\w.]+)$',
                 wrap(self.serve_attachment),
                 name='%s_email_attachment' % appname)
-        ) + urlpatterns
+        ] + urlpatterns
         return urlpatterns
 
     def serve_attachment(self, request, email_id, attachment_id, filename,


### PR DESCRIPTION
# What?
- Removed django.conf.urls.patterns()

# Why?
In django 1.10 django.conf.urls.patterns() will be removed.

# Jira Ticket(s)
[TEEM-9600](https://eventboard.atlassian.net/browse/TEEM-9600)