### PR TITLE
Fix MIMEBase import and smart_text for python 3

### DIFF
--- a/database_email_backend/__init__.py
+++ b/database_email_backend/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-VERSION = (1, 0, 2)
-__version__ = "1.0.2"
+VERSION = (1, 0, 3)
+__version__ = "1.0.3"
 __authors__ = ["Stefan Foulis <stefan.foulis@gmail.com>", ]

--- a/database_email_backend/backend.py
+++ b/database_email_backend/backend.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from email.MIMEBase import MIMEBase
+from email.mime.base import MIMEBase
 
 from django.core.mail.backends.base import BaseEmailBackend
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 
 from database_email_backend.models import Email, Attachment
 
@@ -18,7 +18,7 @@ class DatabaseEmailBackend(BaseEmailBackend):
                 all_recipients=u', '.join(message.recipients()),
                 subject=u'%s' % message.subject,
                 body=u'%s' % message.body,
-                raw=u'%s' % smart_unicode(message.message().as_string()),
+                raw=u'%s' % smart_text(message.message().as_string()),
                 reply_to=u', '.join(message.reply_to)
             )
             for attachment in message.attachments:


### PR DESCRIPTION
What?
=====
- Changed import path of email.MIMEBase.MIMEBase to
email.mime.base.MIMEBase.

- Changed smart_unicode to smart_text for python3.

Why?
=====
- The old path does not exist in python3. The new path exists in both
python2 and python3. In python2, there were two paths that would work
the same way, but the new path is the more correct one.

- smart_unicode aliases to smart_text in python2, and so smart_text is
the new name that works for both python2 and python3.

JIRA Tickets
=====
https://eventboard.atlassian.net/browse/TEEM-16501