### PR TITLE
TE-36159 : Compatible changes for Django 4.2

### DIFF
--- a/database_email_backend/__init__.py
+++ b/database_email_backend/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-VERSION = (1, 0, 5)
-__version__ = "1.0.5"
+VERSION = (2, 0, 0)
+__version__ = "2.0.0"
 __authors__ = ["Stefan Foulis <stefan.foulis@gmail.com>", ]

--- a/database_email_backend/__init__.py
+++ b/database_email_backend/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-VERSION = (1, 0, 4)
-__version__ = "1.0.4"
+VERSION = (1, 0, 5)
+__version__ = "1.0.5"
 __authors__ = ["Stefan Foulis <stefan.foulis@gmail.com>", ]

--- a/database_email_backend/admin.py
+++ b/database_email_backend/admin.py
@@ -8,7 +8,7 @@ from django.http import HttpResponse
 from django.urls import reverse
 from django.core.mail import message
 from django.db.models import Count
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.template.defaultfilters import linebreaks_filter
 
 from database_email_backend.models import Email, Attachment
@@ -72,7 +72,7 @@ class EmailAdmin(admin.ModelAdmin):
 
     def get_urls(self):
         urlpatterns = super(EmailAdmin, self).get_urls()
-        from django.conf.urls import url, include
+        from django.urls import re_path
 
         def wrap(view):
             def wrapper(*args, **kwargs):
@@ -82,7 +82,7 @@ class EmailAdmin(admin.ModelAdmin):
         appname = self.model._meta.app_label
 
         urlpatterns = [
-            url(r'^(?P<email_id>\d+)/attachments/(?P<attachment_id>\d+)/'
+            re_path(r'^(?P<email_id>\d+)/attachments/(?P<attachment_id>\d+)/'
                 r'(?P<filename>[\w.]+)$',
                 wrap(self.serve_attachment),
                 name='%s_email_attachment' % appname)

--- a/database_email_backend/backend.py
+++ b/database_email_backend/backend.py
@@ -2,7 +2,7 @@
 from email.mime.base import MIMEBase
 
 from django.core.mail.backends.base import BaseEmailBackend
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 from database_email_backend.models import Email, Attachment
 
@@ -18,7 +18,7 @@ class DatabaseEmailBackend(BaseEmailBackend):
                 all_recipients=u', '.join(message.recipients()),
                 subject=u'%s' % message.subject,
                 body=u'%s' % message.body,
-                raw=u'%s' % smart_text(message.message().as_string()),
+                raw=u'%s' % smart_str(message.message().as_string()),
                 reply_to=u', '.join(message.reply_to)
             )
             for attachment in message.attachments:


### PR DESCRIPTION
What ?
---

- Changed the import ugettext to gettext
- Changed the import path and function from django.conf.urls import url to django.urls import re_path
- Changed the import smart_text to smart_str

Why ?
---
Support ended
- ugettext is removed in Django 4.2
- import url is removed in Django 4.0+ and re_path is introduced
- smart_text is removed in Django 4.2